### PR TITLE
WIP: autopopulate require git configs from .env

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -21,6 +21,9 @@ services:
       ES_HOST: es
       ES_PORT: '9200'
       LIBRE_TRANSLATE_ENDPOINT: http://libretranslate:5000
+      # Retrieve git config settings from .env file
+      GIT_AUTHOR_NAME: ${GIT_AUTHOR_NAME}
+      GIT_AUTHOR_EMAIL: ${GIT_AUTHOR_EMAIL}
     # Overrides default command so things don't shut down after the process ends.
     command: sleep infinity
     ports:

--- a/.devcontainer/set-git-info.sh
+++ b/.devcontainer/set-git-info.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# probably could be done more efficiently with a list & loop in the future
+
+if [ -z "$GIT_AUTHOR_NAME" == "true" ]; then
+  :
+else
+  git config --global user.name=$GIT_AUTHOR_NAME
+fi
+
+if [ -z "$GIT_AUTHOR_EMAIL" == "true" ]; then
+  :
+else
+  git config --global user.name=$GIT_AUTHOR_EMAIL
+fi


### PR DESCRIPTION
Created this so that we don't have to always redo git config user.name and user.email every time a devcontainer is rebuilt.

Still needs to be tested and verified before being sent to the main mastodon instance.

Put this PR up so i dont forget about it.